### PR TITLE
Fixed preview in Android Studio

### DIFF
--- a/library/src/main/java/com/mypopsy/widget/FloatingSearchView.java
+++ b/library/src/main/java/com/mypopsy/widget/FloatingSearchView.java
@@ -135,7 +135,11 @@ public class FloatingSearchView extends RelativeLayout {
     public FloatingSearchView(Context context, AttributeSet attrs, @AttrRes int defStyleAttr) {
         super(context, attrs, defStyleAttr);
 
-        mActivity = getActivity();
+        if (isInEditMode()) {
+            mActivity = null;
+        } else {
+            mActivity = getActivity();
+        }
 
         setFocusable(true);
         setFocusableInTouchMode(true);
@@ -292,6 +296,7 @@ public class FloatingSearchView extends RelativeLayout {
 
     public void inflateMenu(@MenuRes int menuRes) {
         if(menuRes == 0) return;
+        if (isInEditMode()) return;
         getActivity().getMenuInflater().inflate(menuRes, mActionMenu.getMenu());
 
         XmlResourceParser parser = null;

--- a/library/src/main/res/layout/fsv_floating_search_layout.xml
+++ b/library/src/main/res/layout/fsv_floating_search_layout.xml
@@ -15,8 +15,8 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_below="@+id/fsv_search_container"
-        android:layout_alignStart="@id/fsv_search_container"
-        android:layout_alignLeft="@id/fsv_search_container">
+        android:layout_alignStart="@+id/fsv_search_container"
+        android:layout_alignLeft="@+id/fsv_search_container">
 
         <view class="com.mypopsy.widget.FloatingSearchView$RecyclerView"
               android:id="@+id/fsv_suggestions_list"

--- a/library/src/main/res/layout/fsv_floating_search_layout.xml
+++ b/library/src/main/res/layout/fsv_floating_search_layout.xml
@@ -3,7 +3,7 @@
        xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <include layout="@layout/fsv_search_query_layout"
-             android:id="@+id/fsv.search.container"
+             android:id="@+id/fsv_search_container"
              android:layout_width="match_parent"
              android:layout_height="wrap_content"
              android:layout_centerHorizontal="true"
@@ -11,22 +11,22 @@
              tools:ignore="UnusedAttribute"/>
 
     <FrameLayout
-        android:id="@+id/fsv.suggestions.container"
+        android:id="@+id/fsv_suggestions_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_below="@id/fsv.search.container"
-        android:layout_alignStart="@id/fsv.search.container"
-        android:layout_alignLeft="@id/fsv.search.container">
+        android:layout_below="@id/fsv_search_container"
+        android:layout_alignStart="@id/fsv_search_container"
+        android:layout_alignLeft="@id/fsv_search_container">
 
         <view class="com.mypopsy.widget.FloatingSearchView$RecyclerView"
-              android:id="@+id/fsv.suggestions.list"
+              android:id="@+id/fsv_suggestions_list"
               android:layout_width="match_parent"
               android:layout_height="match_parent"
               android:overScrollMode="never"
               app:layoutManager="LinearLayoutManager"
             />
 
-        <View android:id="@+id/fsv.suggestions.divider"
+        <View android:id="@+id/fsv_suggestions_divider"
               android:layout_width="match_parent"
               android:layout_height="wrap_content"
               android:visibility="invisible"

--- a/library/src/main/res/layout/fsv_floating_search_layout.xml
+++ b/library/src/main/res/layout/fsv_floating_search_layout.xml
@@ -14,7 +14,7 @@
         android:id="@+id/fsv_suggestions_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_below="@id/fsv_search_container"
+        android:layout_below="@+id/fsv_search_container"
         android:layout_alignStart="@id/fsv_search_container"
         android:layout_alignLeft="@id/fsv_search_container">
 

--- a/library/src/main/res/layout/fsv_search_query_layout.xml
+++ b/library/src/main/res/layout/fsv_search_query_layout.xml
@@ -10,13 +10,13 @@
         style="@style/Widget.AppCompat.ActionButton"/>
 
     <ImageButton
-        android:id="@+id/fsv.search.action.navigation"
+        android:id="@+id/fsv_search_action_navigation"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         style="@style/Widget.AppCompat.ActionButton"/>
 
     <view class="com.mypopsy.widget.FloatingSearchView$LogoEditText"
-        android:id="@+id/fsv.search.text"
+        android:id="@+id/fsv_search_text"
         android:layout_width="0dp"
         android:layout_height="match_parent"
         android:layout_weight="1"
@@ -29,7 +29,7 @@
         android:background="@null"/>
 
     <android.support.v7.widget.ActionMenuView
-        android:id="@+id/fsv.search.action.menu"
+        android:id="@+id/fsv_search_action_menu"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:minHeight="48dp"/>

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -6,7 +6,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context="com.mypopsy.floatingsearchview.MainActivity">
+    tools:context="com.mypopsy.floatingsearchview.demo.MainActivity">
 
     <android.support.design.widget.FloatingActionButton
         android:layout_width="wrap_content"
@@ -30,6 +30,7 @@
         android:hint="@string/hint"
         app:logo="@drawable/logo"
         app:fsv_menu="@menu/search"
+        tools:context="com.mypopsy.floatingsearchview.demo.MainActivity"
         app:theme="@style/CustomFloatingSearchViewTheme"/>
 
 </android.support.design.widget.CoordinatorLayout>

--- a/sample/src/main/res/values/styles.xml
+++ b/sample/src/main/res/values/styles.xml
@@ -8,6 +8,7 @@
         <item name="colorAccent">@color/colorAccent</item>
         <item name="colorControlNormal">@color/colorPrimary</item>
         <item name="android:windowBackground">@color/background</item>
+        <item name="floatingSearchViewStyle">@style/CustomFloatingSearchViewTheme</item>
         <item name="android:textAppearanceSearchResultTitle">@style/textAppearanceSearchResultTitle</item>
         <item name="android:textAppearanceSearchResultSubtitle">@style/textAppearanceSearchResultSubTitle</item>
     </style>


### PR DESCRIPTION
Previewing in Android Studio was broken because of periods in layout IDs which it cannot convert to underscores, hence NPEs for all views inside the search view layout.

This was apparent only after the isInEditMode() check for the getActivity() calls because there's no activity in the AS preview either, that threw an IllegalStateException.
